### PR TITLE
fix crash and duplicate symbol warning

### DIFF
--- a/Meander.xcodeproj/project.pbxproj
+++ b/Meander.xcodeproj/project.pbxproj
@@ -876,6 +876,10 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = Meander/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};
@@ -891,6 +895,10 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = Meander/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};


### PR DESCRIPTION
This fixes the crash and the warnings. 

I think the issue was, in Debug, that there type in the Swift Array were say

`Meander.AGSGraphic`

while the expected type was

`WalkKit.AGSGraphic`

Somehow, in Release, this issue was resolved (maybe just a coincidence)

Ultimately, the issue is the way CocoaPods set up the project. WalkKit is linking in the ArcGIS.framework... so that dynamic framework contains ALL ArcGIS symbols. The xcconfig for Pods is also being used for Meander, so the static library for ArcGIS is getting pulled in there as well. You don't get linker errors since technically they are different symbols, but at runtime, it's undefined which one gets used.

So I've fixed it by removing the `ArcGIS.framework`  from Meander's linker line. You could also use `-weak_framework` and that basically just says, don't worry it will exist. 

When you setup the Watch Kit app to use WalkKit, it may try to use the config file so you might want to perform the same change to the Build Settings then.